### PR TITLE
Identify pull request builds from GitHub Actions with the PR number

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -31,6 +31,18 @@ runs:
           SCONS_CACHE_LIMIT: ${{ inputs.scons-cache-limit }}
       run: |
         echo "Building with flags:" platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }}
-        if [ "${{ inputs.target }}" != "editor" ]; then rm -rf editor; fi  # Ensure we don't include editor code.
+
+        if [ "${{ inputs.target }}" != "editor" ]; then
+          # Ensure we don't include editor code in export template builds.
+          rm -rf editor
+        fi
+
+        if [ "${{ github.event.number }}" != "" ]; then
+          # Set build identifier with pull request number if available. This is displayed throughout the editor.
+          export BUILD_NAME="gh-${{ github.event.number }}"
+        else
+          export BUILD_NAME="gh"
+        fi
+
         scons platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }}
         ls -l bin/


### PR DESCRIPTION
This makes it easier to go back to the pull request the build was made from.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
