### PR TITLE
Update renderer_viewport.cpp to check for nearest as well as bilinear before reverting

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -178,17 +178,17 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 				}
 			}
 
-			bool scaling_3d_is_not_bilinear = scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_OFF && scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_BILINEAR;
+			bool scaling_3d_is_not_nearest_or_bilinear = scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_OFF && ((scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_NEAREST) && (scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_BILINEAR));
 			bool use_taa = p_viewport->use_taa;
 
-			if (scaling_3d_is_not_bilinear && (scaling_3d_scale >= (1.0 + EPSILON))) {
+			if (scaling_3d_is_not_nearest_or_bilinear && (scaling_3d_scale >= (1.0 + EPSILON))) {
 				// FSR, MetalFX and nearest-neighbor scaling are not designed for downsampling.
 				// Fall back to bilinear scaling.
 				WARN_PRINT_ONCE("FSR, MetalFX or nearest-neighbor 3D resolution scaling is not designed for downsampling. Falling back to bilinear 3D resolution scaling.");
 				scaling_3d_mode = RS::VIEWPORT_SCALING_3D_MODE_BILINEAR;
 			}
 
-			if (scaling_3d_is_not_bilinear && !upscaler_available) {
+			if (scaling_3d_is_not_nearest_or_bilinear && !upscaler_available) {
 				// FSR is not actually available.
 				// Fall back to bilinear scaling.
 				WARN_PRINT_ONCE("FSR 3D resolution scaling is not available. Falling back to bilinear 3D resolution scaling.");


### PR DESCRIPTION
This change addresses the Compatibility regression with the nearest-neighbour filtering PR where the filter was always coming up bilinear.
https://github.com/godotengine/godot/pull/79731#issuecomment-2767057279

I did some digging, and I think the issue had to do with the check to revert to bilinear filtering if FSR isn't available. By adding an additional check for nearest-neighbour filtering, we prevent the revert logic and warning message from being invoked.

Calling `viewport_set_scaling_3d_mode_below`:
<img width="1528" height="962" alt="Screenshot from 2025-07-24 13-12-25" src="https://github.com/user-attachments/assets/56b0482d-16db-4573-a3b7-4c5efe8b7fc3" />
