### PR TITLE
Drain the raw input queue fully and process leftover WM_INPUT messages

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4254,8 +4254,71 @@ String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
 	return ret;
 }
 
-void DisplayServerWindows::_process_raw_input_event(const RAWINPUT &p_raw, DisplayServerEnums::WindowID p_window_id) {
+Vector2 DisplayServerWindows::_get_raw_mouse_motion(const RAWINPUT &p_raw, DisplayServerEnums::WindowID p_window_id) {
+	if (p_raw.data.mouse.usFlags == MOUSE_MOVE_RELATIVE) {
+		return Vector2(p_raw.data.mouse.lLastX, p_raw.data.mouse.lLastY);
+	} else if (p_raw.data.mouse.usFlags == MOUSE_MOVE_ABSOLUTE) {
+		int nScreenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+		int nScreenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+		int nScreenLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
+		int nScreenTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
+
+		Vector2 abs_pos(
+				(double(p_raw.data.mouse.lLastX) - 65536.0 / (nScreenWidth)) * nScreenWidth / 65536.0 + nScreenLeft,
+				(double(p_raw.data.mouse.lLastY) - 65536.0 / (nScreenHeight)) * nScreenHeight / 65536.0 + nScreenTop);
+
+		POINT coords; // Client coords.
+		coords.x = abs_pos.x;
+		coords.y = abs_pos.y;
+
+		ScreenToClient(windows[p_window_id].hWnd, &coords);
+
+		Vector2 relative(coords.x - old_x, coords.y - old_y);
+		old_x = coords.x;
+		old_y = coords.y;
+		return relative;
+	}
+	return Vector2();
+}
+
+void DisplayServerWindows::_process_raw_mouse_motion(const Vector2 &p_relative, bool p_left_button_down, DisplayServerEnums::WindowID p_window_id) {
+	if (p_relative == Vector2()) {
+		return;
+	}
+
+	Ref<InputEventMouseMotion> mm;
+	mm.instantiate();
 	const BitField<WinKeyModifierMask> &mods = _get_mods();
+
+	mm->set_window_id(p_window_id);
+	mm->set_ctrl_pressed(mods.has_flag(WinKeyModifierMask::CTRL));
+	mm->set_shift_pressed(mods.has_flag(WinKeyModifierMask::SHIFT));
+	mm->set_alt_pressed(mods.has_flag(WinKeyModifierMask::ALT));
+	mm->set_meta_pressed(mods.has_flag(WinKeyModifierMask::META));
+
+	mm->set_pressure(p_left_button_down ? 1.0f : 0.0f);
+	mm->set_button_mask(mouse_get_button_state());
+
+	Point2i c(windows[p_window_id].width / 2, windows[p_window_id].height / 2);
+
+	// Centering just so it works as before.
+	POINT pos = { (int)c.x, (int)c.y };
+	ClientToScreen(windows[p_window_id].hWnd, &pos);
+	SetCursorPos(pos.x, pos.y);
+
+	mm->set_position(c);
+	mm->set_global_position(c);
+	mm->set_velocity(Vector2(0, 0));
+	mm->set_screen_velocity(Vector2(0, 0));
+	mm->set_relative(p_relative);
+	mm->set_relative_screen_position(p_relative);
+
+	if (windows[p_window_id].window_focused || windows[p_window_id].is_popup) {
+		Input::get_singleton()->parse_input_event(mm);
+	}
+}
+
+void DisplayServerWindows::_process_raw_input_event(const RAWINPUT &p_raw, DisplayServerEnums::WindowID p_window_id) {
 	if (p_raw.header.dwType == RIM_TYPEKEYBOARD) {
 		if (p_raw.data.keyboard.VKey == VK_SHIFT) {
 			// If multiple Shifts are held down at the same time,
@@ -4266,6 +4329,7 @@ void DisplayServerWindows::_process_raw_input_event(const RAWINPUT &p_raw, Displ
 				if (GetAsyncKeyState(VK_SHIFT) < 0) {
 					// A Shift is released, but another Shift is still held
 					ERR_FAIL_COND(key_event_pos >= KEY_EVENT_BUFFER_SIZE);
+					const BitField<WinKeyModifierMask> &mods = _get_mods();
 
 					KeyEvent ke;
 					ke.shift = false;
@@ -4285,58 +4349,10 @@ void DisplayServerWindows::_process_raw_input_event(const RAWINPUT &p_raw, Displ
 			}
 		}
 	} else if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED && p_raw.header.dwType == RIM_TYPEMOUSE) {
-		Ref<InputEventMouseMotion> mm;
-		mm.instantiate();
-
-		mm->set_window_id(p_window_id);
-		mm->set_ctrl_pressed(mods.has_flag(WinKeyModifierMask::CTRL));
-		mm->set_shift_pressed(mods.has_flag(WinKeyModifierMask::SHIFT));
-		mm->set_alt_pressed(mods.has_flag(WinKeyModifierMask::ALT));
-		mm->set_meta_pressed(mods.has_flag(WinKeyModifierMask::META));
-
-		mm->set_pressure((p_raw.data.mouse.ulButtons & RI_MOUSE_LEFT_BUTTON_DOWN) ? 1.0f : 0.0f);
-
-		mm->set_button_mask(mouse_get_button_state());
-
-		Point2i c(windows[p_window_id].width / 2, windows[p_window_id].height / 2);
-
-		// Centering just so it works as before.
-		POINT pos = { (int)c.x, (int)c.y };
-		ClientToScreen(windows[p_window_id].hWnd, &pos);
-		SetCursorPos(pos.x, pos.y);
-
-		mm->set_position(c);
-		mm->set_global_position(c);
-		mm->set_velocity(Vector2(0, 0));
-		mm->set_screen_velocity(Vector2(0, 0));
-
-		if (p_raw.data.mouse.usFlags == MOUSE_MOVE_RELATIVE) {
-			mm->set_relative(Vector2(p_raw.data.mouse.lLastX, p_raw.data.mouse.lLastY));
-		} else if (p_raw.data.mouse.usFlags == MOUSE_MOVE_ABSOLUTE) {
-			int nScreenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-			int nScreenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
-			int nScreenLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
-			int nScreenTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
-
-			Vector2 abs_pos(
-					(double(p_raw.data.mouse.lLastX) - 65536.0 / (nScreenWidth)) * nScreenWidth / 65536.0 + nScreenLeft,
-					(double(p_raw.data.mouse.lLastY) - 65536.0 / (nScreenHeight)) * nScreenHeight / 65536.0 + nScreenTop);
-
-			POINT coords; // Client coords.
-			coords.x = abs_pos.x;
-			coords.y = abs_pos.y;
-
-			ScreenToClient(windows[p_window_id].hWnd, &coords);
-
-			mm->set_relative(Vector2(coords.x - old_x, coords.y - old_y));
-			old_x = coords.x;
-			old_y = coords.y;
-		}
-		mm->set_relative_screen_position(mm->get_relative());
-
-		if ((windows[p_window_id].window_focused || windows[p_window_id].is_popup) && mm->get_relative() != Vector2()) {
-			Input::get_singleton()->parse_input_event(mm);
-		}
+		_process_raw_mouse_motion(
+				_get_raw_mouse_motion(p_raw, p_window_id),
+				p_raw.data.mouse.ulButtons & RI_MOUSE_LEFT_BUTTON_DOWN,
+				p_window_id);
 	}
 }
 
@@ -4352,25 +4368,28 @@ void DisplayServerWindows::process_raw_input() {
 		window_id = DisplayServerEnums::MAIN_WINDOW_ID;
 	}
 
-	// Read repeatedly until the queue reports empty. A single read returns at
-	// most a buffer's worth of events, and the remainder would otherwise sit in
-	// the queue as WM_INPUT messages (a growing backlog during fast mouse
-	// movement, or events consumed unread if the message pump dispatches them).
-	// The drain must not be bounded by a small pass count: when a long frame
-	// (such as a scene load) overlaps mouse motion, the thread's message queue
-	// reaches the 10,000-message Windows cap, after which the OS drops every
-	// new hardware message (clicks and keys included) until the backlog is
-	// consumed. A bounded drain at a low frame rate (an unfocused editor idles
-	// near 10 FPS) can then never catch up with a high-polling mouse, which
-	// presents as a permanently frozen, input-dead window. Unlike a
-	// per-message pump, "until empty" cannot spin here: one buffered read
-	// consumes tens of events in microseconds while new packets arrive 125 us
-	// apart at 8,000 Hz, so arrival never keeps pace with the drain.
+	// ponytail: normal 8 kHz frames stay precise; only a stall-sized tail is coalesced.
+	constexpr UINT MAX_RAW_MOUSE_EVENTS_PER_FRAME = 512;
+	UINT raw_mouse_events = 0;
+	Vector2 coalesced_raw_mouse_motion;
+	bool coalesced_raw_mouse_left_button_down = false;
+	const bool coalesce_all_raw_mouse_motion = Input::get_singleton()->is_using_accumulated_input();
+	auto flush_coalesced_raw_mouse_motion = [&]() {
+		_process_raw_mouse_motion(coalesced_raw_mouse_motion, coalesced_raw_mouse_left_button_down, window_id);
+		coalesced_raw_mouse_motion = Vector2();
+		coalesced_raw_mouse_left_button_down = false;
+	};
+
+	// Read until the raw queue is empty. A small pass cap can never catch up
+	// after a long stall reaches Windows' 10,000-message queue limit, but a
+	// stall-sized captured mouse tail is coalesced below before it reaches the
+	// rest of the engine.
 	while (true) {
 		UINT n_buffer = 0;
 		// With a null buffer, this reports the byte size of the first pending
 		// message (the minimum required buffer), not a message count.
 		if (GetRawInputBuffer(nullptr, &n_buffer, sizeof(RAWINPUTHEADER)) != 0 || n_buffer == 0) {
+			flush_coalesced_raw_mouse_motion();
 			return;
 		}
 
@@ -4380,12 +4399,24 @@ void DisplayServerWindows::process_raw_input() {
 		UINT n_read = GetRawInputBuffer((PRAWINPUT)lpb, &dw_size, sizeof(RAWINPUTHEADER)); // Note: use dw_size, not n_buffer.
 		if (n_read == (UINT)-1 || n_read == 0) {
 			delete[] lpb;
+			flush_coalesced_raw_mouse_motion();
 			return;
 		}
 
 		PRAWINPUT raw = (PRAWINPUT)lpb;
 		for (UINT i = 0; i < n_read; ++i) {
-			_process_raw_input_event(*raw, window_id);
+			if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED &&
+					raw->header.dwType == RIM_TYPEMOUSE &&
+					(coalesce_all_raw_mouse_motion || raw_mouse_events >= MAX_RAW_MOUSE_EVENTS_PER_FRAME)) {
+				coalesced_raw_mouse_motion += _get_raw_mouse_motion(*raw, window_id);
+				coalesced_raw_mouse_left_button_down = coalesced_raw_mouse_left_button_down ||
+						(raw->data.mouse.ulButtons & RI_MOUSE_LEFT_BUTTON_DOWN);
+			} else {
+				_process_raw_input_event(*raw, window_id);
+			}
+			if (raw->header.dwType == RIM_TYPEMOUSE) {
+				raw_mouse_events++;
+			}
 			// Move to next RAWINPUT in buffer
 			raw = NEXTRAWINPUTBLOCK(raw);
 		}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4356,11 +4356,17 @@ void DisplayServerWindows::process_raw_input() {
 	// most a buffer's worth of events, and the remainder would otherwise sit in
 	// the queue as WM_INPUT messages (a growing backlog during fast mouse
 	// movement, or events consumed unread if the message pump dispatches them).
-	// Bound the passes: raw input arrives continuously at high polling rates
-	// (every 125 us at 8,000 Hz), so "until empty" alone could keep this loop
-	// fed for as long as the mouse is moving. The bound is far above any real
-	// per-frame arrival count; leftovers are read next frame.
-	for (int pass = 0; pass < 16; pass++) {
+	// The drain must not be bounded by a small pass count: when a long frame
+	// (such as a scene load) overlaps mouse motion, the thread's message queue
+	// reaches the 10,000-message Windows cap, after which the OS drops every
+	// new hardware message (clicks and keys included) until the backlog is
+	// consumed. A bounded drain at a low frame rate (an unfocused editor idles
+	// near 10 FPS) can then never catch up with a high-polling mouse, which
+	// presents as a permanently frozen, input-dead window. Unlike a
+	// per-message pump, "until empty" cannot spin here: one buffered read
+	// consumes tens of events in microseconds while new packets arrive 125 us
+	// apart at 8,000 Hz, so arrival never keeps pace with the drain.
+	while (true) {
 		UINT n_buffer = 0;
 		// With a null buffer, this reports the byte size of the first pending
 		// message (the minimum required buffer), not a message count.

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4398,61 +4398,20 @@ void DisplayServerWindows::process_events() {
 
 	process_raw_input();
 
-	MSG msg = {};
-	// Peek all messages except `WM_INPUT` if the window is focused.
-	auto peekNotInput = [&] {
-		if (!app_focused) {
-			return PeekMessage(&msg, NULL, 0, 0, PM_REMOVE);
-		}
-		BOOL ret = PeekMessage(&msg, NULL, 0, WM_INPUT - 1, PM_REMOVE);
-		// Avoid polling what we're polling further below in `peekKeysMouseButtons()`.
-		if (!ret) {
-			ret = PeekMessage(&msg, NULL, WM_INPUT + 3, WM_MOUSEMOVE, PM_REMOVE);
-		}
-		if (!ret) {
-			ret = PeekMessage(&msg, NULL, WM_MOUSELAST + 1, std::numeric_limits<UINT>::max(), PM_REMOVE);
-		}
-		return ret;
-	};
-
-	// Peek only keyboard and mouse button messages separately, with its own limit.
-	auto peekKeysMouseButtons = [&] {
-		BOOL ret = PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYUP, PM_REMOVE);
-		if (!ret) {
-			// Do not process `WM_MOUSEMOVE` here.
-			ret = PeekMessage(&msg, NULL, WM_LBUTTONDOWN, WM_MOUSELAST, PM_REMOVE);
-		}
-		return ret;
-	};
-
-	// Only process a limited number of events per frame to avoid blocking for too long
-	// due to `PeekMessage()` being relatively slow.
-	// This is what avoids performance issues with high polling rate mice (2,000 Hz and above).
-	//
-	// In practice, when input accumulation is disabled:
-	//
-	// - In captured mouse mode, as many mouse events as possible will be processed
-	//   (this seems to perform fine).
-	// - In other mouse modes, up to 5 events per rendered frame will be processed.
-	//
+	// The message pump can drain the queue unthrottled: process_raw_input()
+	// already consumed the WM_INPUT flood through GetRawInputBuffer(), and
+	// legacy WM_MOUSEMOVE is coalesced by the OS, so high polling rate mice
+	// (2,000 Hz and above) no longer overwhelm PeekMessage().
 	// See <https://ph3at.github.io/posts/Windows-Input/> for more information.
-	int events_processed_this_frame = 0;
-	int events_processed_this_frame_kmb = 0;
-	constexpr int MAX_EVENTS_PER_FRAME = 1;
-	constexpr int MAX_EVENTS_PER_FRAME_KMB = 1;
-
-	while (events_processed_this_frame < MAX_EVENTS_PER_FRAME && peekNotInput()) {
+	//
+	// Capping events per frame here would split the WM_CHAR posted by
+	// TranslateMessage() from its WM_KEYDOWN across frames, which breaks the
+	// pairing logic in _process_key_events() and makes keys fire twice.
+	MSG msg = {};
+	while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
 		TranslateMessage(&msg);
 		DispatchMessageW(&msg);
-		events_processed_this_frame += 1;
 	}
-
-	if (events_processed_this_frame_kmb < MAX_EVENTS_PER_FRAME_KMB && peekKeysMouseButtons()) {
-		TranslateMessage(&msg);
-		DispatchMessageW(&msg);
-		events_processed_this_frame_kmb += 1;
-	}
-
 	_THREAD_SAFE_UNLOCK_
 
 	if (tts) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4356,7 +4356,11 @@ void DisplayServerWindows::process_raw_input() {
 	// most a buffer's worth of events, and the remainder would otherwise sit in
 	// the queue as WM_INPUT messages (a growing backlog during fast mouse
 	// movement, or events consumed unread if the message pump dispatches them).
-	while (true) {
+	// Bound the passes: raw input arrives continuously at high polling rates
+	// (every 125 us at 8,000 Hz), so "until empty" alone could keep this loop
+	// fed for as long as the mouse is moving. The bound is far above any real
+	// per-frame arrival count; leftovers are read next frame.
+	for (int pass = 0; pass < 16; pass++) {
 		UINT n_buffer = 0;
 		// With a null buffer, this reports the byte size of the first pending
 		// message (the minimum required buffer), not a message count.
@@ -4398,17 +4402,48 @@ void DisplayServerWindows::process_events() {
 
 	process_raw_input();
 
-	// The message pump can drain the queue unthrottled: process_raw_input()
-	// already consumed the WM_INPUT flood through GetRawInputBuffer(), and
-	// legacy WM_MOUSEMOVE is coalesced by the OS, so high polling rate mice
-	// (2,000 Hz and above) no longer overwhelm PeekMessage().
+	// The pump throttles only what the hardware can flood, and drains the rest.
 	// See <https://ph3at.github.io/posts/Windows-Input/> for more information.
 	//
-	// Capping events per frame here would split the WM_CHAR posted by
-	// TranslateMessage() from its WM_KEYDOWN across frames, which breaks the
-	// pairing logic in _process_key_events() and makes keys fire twice.
+	// - WM_INPUT is never dispatched from here: pulling raw input through
+	//   PeekMessage() one message at a time is what collapses the pump at high
+	//   polling rates (2,000 Hz and above). It stays in the queue for the next
+	//   buffered read in process_raw_input().
+	// - WM_MOUSEMOVE and WM_NCMOUSEMOVE are synthesized on demand from the
+	//   hardware input stream, so while the mouse is moving the queue never
+	//   reads empty and an unbounded pump spins until the mouse stops. They are
+	//   dispatched at most once per frame each. No motion is lost: they carry
+	//   the latest (coalesced) cursor position, and the relative motion derived
+	//   from successive positions preserves the total delta. Captured mouse
+	//   mode gets its sub-frame motion from raw input.
+	// - Everything else (keys, characters, mouse buttons, wheel, system
+	//   messages) is discrete and low-rate, and is drained fully. Capping these
+	//   would split the WM_CHAR posted by TranslateMessage() from its
+	//   WM_KEYDOWN across frames, which breaks the pairing logic in
+	//   _process_key_events() and makes keys fire twice.
 	MSG msg = {};
-	while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+	auto peek_discrete = [&] {
+		BOOL ret = PeekMessageW(&msg, nullptr, 0, WM_NCMOUSEMOVE - 1, PM_REMOVE);
+		if (!ret) {
+			ret = PeekMessageW(&msg, nullptr, WM_NCMOUSEMOVE + 1, WM_INPUT - 1, PM_REMOVE);
+		}
+		if (!ret) {
+			ret = PeekMessageW(&msg, nullptr, WM_INPUT + 1, WM_MOUSEMOVE - 1, PM_REMOVE);
+		}
+		if (!ret) {
+			ret = PeekMessageW(&msg, nullptr, WM_MOUSEMOVE + 1, std::numeric_limits<UINT>::max(), PM_REMOVE);
+		}
+		return ret;
+	};
+	while (peek_discrete()) {
+		TranslateMessage(&msg);
+		DispatchMessageW(&msg);
+	}
+	if (PeekMessageW(&msg, nullptr, WM_MOUSEMOVE, WM_MOUSEMOVE, PM_REMOVE)) {
+		TranslateMessage(&msg);
+		DispatchMessageW(&msg);
+	}
+	if (PeekMessageW(&msg, nullptr, WM_NCMOUSEMOVE, WM_NCMOUSEMOVE, PM_REMOVE)) {
 		TranslateMessage(&msg);
 		DispatchMessageW(&msg);
 	}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4254,120 +4254,133 @@ String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
 	return ret;
 }
 
-void DisplayServerWindows::process_raw_input() {
-	DisplayServerEnums::WindowID window_id = DisplayServerEnums::MAIN_WINDOW_ID;
+void DisplayServerWindows::_process_raw_input_event(const RAWINPUT &p_raw, DisplayServerEnums::WindowID p_window_id) {
+	const BitField<WinKeyModifierMask> &mods = _get_mods();
+	if (p_raw.header.dwType == RIM_TYPEKEYBOARD) {
+		if (p_raw.data.keyboard.VKey == VK_SHIFT) {
+			// If multiple Shifts are held down at the same time,
+			// Windows natively only sends a KEYUP for the last one to be released.
+			if (p_raw.data.keyboard.Flags & RI_KEY_BREAK) {
+				// Make sure to check the latest key state since
+				// we're in the middle of the message queue.
+				if (GetAsyncKeyState(VK_SHIFT) < 0) {
+					// A Shift is released, but another Shift is still held
+					ERR_FAIL_COND(key_event_pos >= KEY_EVENT_BUFFER_SIZE);
 
+					KeyEvent ke;
+					ke.shift = false;
+					ke.altgr = mods.has_flag(WinKeyModifierMask::ALT_GR);
+					ke.alt = mods.has_flag(WinKeyModifierMask::ALT);
+					ke.control = mods.has_flag(WinKeyModifierMask::CTRL);
+					ke.meta = mods.has_flag(WinKeyModifierMask::META);
+					ke.uMsg = WM_KEYUP;
+					ke.window_id = p_window_id;
+
+					ke.wParam = VK_SHIFT;
+					// data.keyboard.MakeCode -> 0x2A - left shift, 0x36 - right shift.
+					// Bit 30 -> key was previously down, bit 31 -> key is being released.
+					ke.lParam = p_raw.data.keyboard.MakeCode << 16 | 1 << 30 | 1 << 31;
+					key_event_buffer[key_event_pos++] = ke;
+				}
+			}
+		}
+	} else if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED && p_raw.header.dwType == RIM_TYPEMOUSE) {
+		Ref<InputEventMouseMotion> mm;
+		mm.instantiate();
+
+		mm->set_window_id(p_window_id);
+		mm->set_ctrl_pressed(mods.has_flag(WinKeyModifierMask::CTRL));
+		mm->set_shift_pressed(mods.has_flag(WinKeyModifierMask::SHIFT));
+		mm->set_alt_pressed(mods.has_flag(WinKeyModifierMask::ALT));
+		mm->set_meta_pressed(mods.has_flag(WinKeyModifierMask::META));
+
+		mm->set_pressure((p_raw.data.mouse.ulButtons & RI_MOUSE_LEFT_BUTTON_DOWN) ? 1.0f : 0.0f);
+
+		mm->set_button_mask(mouse_get_button_state());
+
+		Point2i c(windows[p_window_id].width / 2, windows[p_window_id].height / 2);
+
+		// Centering just so it works as before.
+		POINT pos = { (int)c.x, (int)c.y };
+		ClientToScreen(windows[p_window_id].hWnd, &pos);
+		SetCursorPos(pos.x, pos.y);
+
+		mm->set_position(c);
+		mm->set_global_position(c);
+		mm->set_velocity(Vector2(0, 0));
+		mm->set_screen_velocity(Vector2(0, 0));
+
+		if (p_raw.data.mouse.usFlags == MOUSE_MOVE_RELATIVE) {
+			mm->set_relative(Vector2(p_raw.data.mouse.lLastX, p_raw.data.mouse.lLastY));
+		} else if (p_raw.data.mouse.usFlags == MOUSE_MOVE_ABSOLUTE) {
+			int nScreenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+			int nScreenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+			int nScreenLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
+			int nScreenTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
+
+			Vector2 abs_pos(
+					(double(p_raw.data.mouse.lLastX) - 65536.0 / (nScreenWidth)) * nScreenWidth / 65536.0 + nScreenLeft,
+					(double(p_raw.data.mouse.lLastY) - 65536.0 / (nScreenHeight)) * nScreenHeight / 65536.0 + nScreenTop);
+
+			POINT coords; // Client coords.
+			coords.x = abs_pos.x;
+			coords.y = abs_pos.y;
+
+			ScreenToClient(windows[p_window_id].hWnd, &coords);
+
+			mm->set_relative(Vector2(coords.x - old_x, coords.y - old_y));
+			old_x = coords.x;
+			old_y = coords.y;
+		}
+		mm->set_relative_screen_position(mm->get_relative());
+
+		if ((windows[p_window_id].window_focused || windows[p_window_id].is_popup) && mm->get_relative() != Vector2()) {
+			Input::get_singleton()->parse_input_event(mm);
+		}
+	}
+}
+
+void DisplayServerWindows::process_raw_input() {
 	if (!use_raw_input) {
 		return;
 	}
 
-	UINT n_buffer;
-	// First, get the number of RAWINPUT structures in the buffer.
-	if (GetRawInputBuffer(nullptr, &n_buffer, sizeof(RAWINPUTHEADER)) != 0 || n_buffer == 0) {
-		return;
+	// Use the same window the mouse is captured for in _set_mouse_mode_impl(),
+	// which is not necessarily the main window.
+	DisplayServerEnums::WindowID window_id = _get_focused_window_or_popup();
+	if (!windows.has(window_id)) {
+		window_id = DisplayServerEnums::MAIN_WINDOW_ID;
 	}
 
-	UINT dw_size = n_buffer * sizeof(RAWINPUT);
-	LPBYTE lpb = new BYTE[dw_size];
-	if (lpb == nullptr) {
-		return;
-	}
-
-	UINT n_read = GetRawInputBuffer((PRAWINPUT)lpb, &dw_size, sizeof(RAWINPUTHEADER)); // Note: use dw_size, not n_buffer.
-	if (n_read == (UINT)-1 || n_read == 0) {
-		delete[] lpb;
-		return;
-	}
-
-	PRAWINPUT raw = (PRAWINPUT)lpb;
-	for (UINT i = 0; i < n_read; ++i) {
-		const BitField<WinKeyModifierMask> &mods = _get_mods();
-		if (raw->header.dwType == RIM_TYPEKEYBOARD) {
-			if (raw->data.keyboard.VKey == VK_SHIFT) {
-				// If multiple Shifts are held down at the same time,
-				// Windows natively only sends a KEYUP for the last one to be released.
-				if (raw->data.keyboard.Flags & RI_KEY_BREAK) {
-					// Make sure to check the latest key state since
-					// we're in the middle of the message queue.
-					if (GetAsyncKeyState(VK_SHIFT) < 0) {
-						// A Shift is released, but another Shift is still held
-						ERR_BREAK(key_event_pos >= KEY_EVENT_BUFFER_SIZE);
-
-						KeyEvent ke;
-						ke.shift = false;
-						ke.altgr = mods.has_flag(WinKeyModifierMask::ALT_GR);
-						ke.alt = mods.has_flag(WinKeyModifierMask::ALT);
-						ke.control = mods.has_flag(WinKeyModifierMask::CTRL);
-						ke.meta = mods.has_flag(WinKeyModifierMask::META);
-						ke.uMsg = WM_KEYUP;
-						ke.window_id = window_id;
-
-						ke.wParam = VK_SHIFT;
-						// data.keyboard.MakeCode -> 0x2A - left shift, 0x36 - right shift.
-						// Bit 30 -> key was previously down, bit 31 -> key is being released.
-						ke.lParam = raw->data.keyboard.MakeCode << 16 | 1 << 30 | 1 << 31;
-						key_event_buffer[key_event_pos++] = ke;
-					}
-				}
-			}
-		} else if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED && raw->header.dwType == RIM_TYPEMOUSE) {
-			Ref<InputEventMouseMotion> mm;
-			mm.instantiate();
-
-			mm->set_window_id(window_id);
-			mm->set_ctrl_pressed(mods.has_flag(WinKeyModifierMask::CTRL));
-			mm->set_shift_pressed(mods.has_flag(WinKeyModifierMask::SHIFT));
-			mm->set_alt_pressed(mods.has_flag(WinKeyModifierMask::ALT));
-			mm->set_meta_pressed(mods.has_flag(WinKeyModifierMask::META));
-
-			mm->set_pressure((raw->data.mouse.ulButtons & RI_MOUSE_LEFT_BUTTON_DOWN) ? 1.0f : 0.0f);
-
-			mm->set_button_mask(mouse_get_button_state());
-
-			Point2i c(windows[window_id].width / 2, windows[window_id].height / 2);
-
-			// Centering just so it works as before.
-			POINT pos = { (int)c.x, (int)c.y };
-			ClientToScreen(windows[window_id].hWnd, &pos);
-			SetCursorPos(pos.x, pos.y);
-
-			mm->set_position(c);
-			mm->set_global_position(c);
-			mm->set_velocity(Vector2(0, 0));
-			mm->set_screen_velocity(Vector2(0, 0));
-
-			if (raw->data.mouse.usFlags == MOUSE_MOVE_RELATIVE) {
-				mm->set_relative(Vector2(raw->data.mouse.lLastX, raw->data.mouse.lLastY));
-			} else if (raw->data.mouse.usFlags == MOUSE_MOVE_ABSOLUTE) {
-				int nScreenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-				int nScreenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
-				int nScreenLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
-				int nScreenTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
-
-				Vector2 abs_pos(
-						(double(raw->data.mouse.lLastX) - 65536.0 / (nScreenWidth)) * nScreenWidth / 65536.0 + nScreenLeft,
-						(double(raw->data.mouse.lLastY) - 65536.0 / (nScreenHeight)) * nScreenHeight / 65536.0 + nScreenTop);
-
-				POINT coords; // Client coords.
-				coords.x = abs_pos.x;
-				coords.y = abs_pos.y;
-
-				ScreenToClient(windows[window_id].hWnd, &coords);
-
-				mm->set_relative(Vector2(coords.x - old_x, coords.y - old_y));
-				old_x = coords.x;
-				old_y = coords.y;
-			}
-			mm->set_relative_screen_position(mm->get_relative());
-
-			if ((windows[window_id].window_focused || windows[window_id].is_popup) && mm->get_relative() != Vector2()) {
-				Input::get_singleton()->parse_input_event(mm);
-			}
+	// Read repeatedly until the queue reports empty. A single read returns at
+	// most a buffer's worth of events, and the remainder would otherwise sit in
+	// the queue as WM_INPUT messages (a growing backlog during fast mouse
+	// movement, or events consumed unread if the message pump dispatches them).
+	while (true) {
+		UINT n_buffer = 0;
+		// With a null buffer, this reports the byte size of the first pending
+		// message (the minimum required buffer), not a message count.
+		if (GetRawInputBuffer(nullptr, &n_buffer, sizeof(RAWINPUTHEADER)) != 0 || n_buffer == 0) {
+			return;
 		}
-		// Move to next RAWINPUT in buffer
-		raw = NEXTRAWINPUTBLOCK(raw);
+
+		UINT dw_size = n_buffer * sizeof(RAWINPUT);
+		LPBYTE lpb = new BYTE[dw_size];
+
+		UINT n_read = GetRawInputBuffer((PRAWINPUT)lpb, &dw_size, sizeof(RAWINPUTHEADER)); // Note: use dw_size, not n_buffer.
+		if (n_read == (UINT)-1 || n_read == 0) {
+			delete[] lpb;
+			return;
+		}
+
+		PRAWINPUT raw = (PRAWINPUT)lpb;
+		for (UINT i = 0; i < n_read; ++i) {
+			_process_raw_input_event(*raw, window_id);
+			// Move to next RAWINPUT in buffer
+			raw = NEXTRAWINPUTBLOCK(raw);
+		}
+		delete[] lpb;
 	}
-	delete[] lpb;
 }
 
 void DisplayServerWindows::process_events() {
@@ -5825,6 +5838,28 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				track_mouse_leave_event(windows[window_mouseover_id].hWnd);
 			}
 
+		} break;
+		case WM_INPUT: {
+			if (!use_raw_input) {
+				break;
+			}
+
+			// The bulk of raw input is drained in batch by process_raw_input()
+			// before the message pump runs. This only sees WM_INPUT messages the
+			// pump picks up afterwards (it peeks the full message range whenever
+			// the app is not focused, and raw input can also arrive while the pump
+			// itself is running). Without this fallback, DefWindowProc() would
+			// free their data unread.
+			UINT dwSize;
+			if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, nullptr, &dwSize, sizeof(RAWINPUTHEADER)) != 0 || dwSize == 0) {
+				break;
+			}
+
+			LPBYTE lpb = new BYTE[dwSize];
+			if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, lpb, &dwSize, sizeof(RAWINPUTHEADER)) == dwSize) {
+				_process_raw_input_event(*(RAWINPUT *)lpb, window_id);
+			}
+			delete[] lpb;
 		} break;
 		case WT_CSRCHANGE:
 		case WT_PROXIMITY: {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -552,6 +552,8 @@ class DisplayServerWindows : public DisplayServer {
 
 	void initialize_tts() const;
 	void process_raw_input();
+	Vector2 _get_raw_mouse_motion(const RAWINPUT &p_raw, DisplayServerEnums::WindowID p_window_id);
+	void _process_raw_mouse_motion(const Vector2 &p_relative, bool p_left_button_down, DisplayServerEnums::WindowID p_window_id);
 	void _process_raw_input_event(const RAWINPUT &p_raw, DisplayServerEnums::WindowID p_window_id);
 
 	struct ScreenHdrData {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -552,6 +552,7 @@ class DisplayServerWindows : public DisplayServer {
 
 	void initialize_tts() const;
 	void process_raw_input();
+	void _process_raw_input_event(const RAWINPUT &p_raw, DisplayServerEnums::WindowID p_window_id);
 
 	struct ScreenHdrData {
 		bool hdr_supported = false;

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -68,6 +68,13 @@ char *wc_to_utf8(const wchar_t *wc) {
 int widechar_main(int argc, wchar_t **argv) {
 	godot_init_profiler();
 
+	// Prevent Windows from replacing the window with a "ghost" when the main
+	// thread briefly stalls (e.g. during editor startup or focus transitions).
+	// The ghost window intercepts click-backs, so the editor never receives
+	// WM_ACTIVATEAPP and gets permanently stuck at the unfocused throttle.
+	// Must be called before any window is created.
+	DisableProcessWindowsGhosting();
+
 	OS_Windows os(nullptr);
 
 	setlocale(LC_CTYPE, "");


### PR DESCRIPTION
Follow-up to the issues I listed in [this comment](https://github.com/godotengine/godot/pull/109639#issuecomment-4666039148) on godotengine/godot#109639. This fixes points 1, 2 and 4 from there.

- `process_raw_input()` now calls `GetRawInputBuffer()` in a loop until the queue reports empty. With a null buffer the API returns the byte size of the *first* pending message in `pcbSize`, not a message count, so the single read held about 48 mouse events. An 8,000 Hz mouse at 60 FPS (~133 events per frame) left a remainder behind every frame during fast movement.
- The per-event parsing moved into `_process_raw_input_event()`, shared between the buffered read and a restored `WM_INPUT` handler in `WndProc`. The pump can still pick up `WM_INPUT` messages (it peeks the full message range whenever the app isn't focused, and raw input can also arrive while the pump itself is running), and without a handler `DefWindowProc()` frees their data unread. The handler only sees a handful of stragglers per frame, so the flood your PR fixes can't come back through it.
- The buffered path now targets `_get_focused_window_or_popup()` with a main-window fallback instead of hardcoding `MAIN_WINDOW_ID`. That's the same window `_set_mouse_mode_impl()` captures the mouse for.

I left point 3 (the WOW64 alignment rules for 32-bit processes) alone. The simplest option there might be to skip the buffered path on 32-bit and let the restored `WM_INPUT` handler carry it, but that would also need the `PeekMessage()` filters disabled on 32-bit, so I didn't want to bundle it in here.

I've been running the same fixes in my own fork, which drains the message queue without the caps (per my earlier comment). On this branch I've verified it builds and the editor runs, but I haven't stress-tested it against the caps, so it's worth a pass with your 8,000 Hz mouse.
